### PR TITLE
ci: add PR dependency check

### DIFF
--- a/.github/workflows/prcheck.yml
+++ b/.github/workflows/prcheck.yml
@@ -1,7 +1,7 @@
 name: PR Checks
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - synchronize
@@ -16,3 +16,8 @@ jobs:
       - uses: aslafy-z/conventional-pr-title-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  check-dependencies:
+    name: Check Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: gregsdennis/dependencies-action@1.2.3


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--
Before you start, please make sure your issue is understandable and reproducible.
To make your issue readable make sure you use valid Markdown syntax.
https://guides.github.com/features/mastering-markdown/
-->

### What does it do

Added an action to allow us to mark a PR as a dependency of another one.

### Usage

This will be useful for #9 y #8.

### Why is it needed

We currently have a need for this with #9 and #8.

### Related issue(s)/PR(s)

#9, #8.

