### PR TITLE
fix: deleted unnecessary expanded widget

### DIFF
--- a/lib/pages/courses/course_page.dart
+++ b/lib/pages/courses/course_page.dart
@@ -35,31 +35,29 @@ class CoursePage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.all(16),
-      child: Expanded(
-        child: Material(
-          color: Colors.transparent,
-          clipBehavior: Clip.antiAlias,
-          child: ListView.separated(
-            itemCount: _courses.length,
-            itemBuilder: (context, index) {
-              final course = _courses[index];
-              return InfoCard(
-                backgroundColor: course.backgroundColor,
-                title: Text(course.courseName),
-                children: [
-                  InfoCardItem(
-                    leading: const Icon(Icons.badge),
-                    child: Text(course.teacherName),
-                  ),
-                  InfoCardItem(
-                    leading: const Icon(Icons.date_range),
-                    child: Text(course.frequency),
-                  ),
-                ],
-              );
-            },
-            separatorBuilder: (_, __) => const SizedBox(height: 16),
-          ),
+      child: Material(
+        color: Colors.transparent,
+        clipBehavior: Clip.antiAlias,
+        child: ListView.separated(
+          itemCount: _courses.length,
+          itemBuilder: (context, index) {
+            final course = _courses[index];
+            return InfoCard(
+              backgroundColor: course.backgroundColor,
+              title: Text(course.courseName),
+              children: [
+                InfoCardItem(
+                  leading: const Icon(Icons.badge),
+                  child: Text(course.teacherName),
+                ),
+                InfoCardItem(
+                  leading: const Icon(Icons.date_range),
+                  child: Text(course.frequency),
+                ),
+              ],
+            );
+          },
+          separatorBuilder: (_, __) => const SizedBox(height: 16),
         ),
       ),
     );


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--
Before you start, please make sure your issue is understandable and reproducible.
To make your issue readable make sure you use valid Markdown syntax.
https://guides.github.com/features/mastering-markdown/
-->

### What does it do

Deleted unnecessary ```Expanded``` widget in courses page.

### Why is it needed

Avoid exceptions in debug console.

### Related issue(s)/PR(s)

Fixes #23 

### Additional context

The problem, in fact, was generated by the ```Expanded``` widget,  which only possible parent widgets can be ```Row, Column, Flex```. See about the problem here: [ [Solved] Incorrect use of ParentDataWidget Error in Flutter](https://www.fluttercampus.com/guide/229/incorrect-use-of-parentdatawidget-error/)
