### PR TITLE
fix(android): missing internet access permission

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.youniversity_app">
-   <application
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    
+    <application
         android:label="youniversity_app"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
@@ -17,12 +20,12 @@
                  while the Flutter UI initializes. After that, this theme continues
                  to determine the Window background behind the Flutter UI. -->
             <meta-data
-              android:name="io.flutter.embedding.android.NormalTheme"
-              android:resource="@style/NormalTheme"
-              />
+                android:name="io.flutter.embedding.android.NormalTheme"
+                android:resource="@style/NormalTheme"
+            />
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--
Before you start, please make sure your issue is understandable and reproducible.
To make your issue readable make sure you use valid Markdown syntax.
https://guides.github.com/features/mastering-markdown/
-->

### What does it do

Added `android.permission.INTERNET` permission to AndroidManifest.xml for the release version of the app.

### Why is it needed

Without this the app will not communicate with the backend.

### Related issue(s)/PR(s)

The implementation of BLoC for authentication was done in #25

### Additional context

During debugging, Flutter automatically adds the internet permission to the manifest so that the app can communicate with the debugger.
